### PR TITLE
Add an airdrop component

### DIFF
--- a/basic/airdrop/Cargo.toml
+++ b/basic/airdrop/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "airdrop"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sbor = { path = "../../sbor" }
+scrypto = { path = "../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../radix-engine" }
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "out"

--- a/basic/airdrop/README.md
+++ b/basic/airdrop/README.md
@@ -1,0 +1,56 @@
+# airdrop
+
+Example for an airdrop component that demonstrates how tokens can be sent to account addresses from within a component.
+Additional the code in `tests/libs.rs` shows how token balances can be retrieved in unit tests.
+
+The component is implemented in its simplest form to showcase the above two points. Authorization is not implemented.
+
+# Implementation
+
+An airdrop component is instantiated without any arguments. It only holds one field, which is a vector that tracks the
+recipients of an airdrop:
+
+```rust
+pub fn new() -> Component {
+    Self {
+        recipients: Vec::new(),
+    }
+        .instantiate()
+}
+```
+
+Before distributing an airdrop, one needs to first add at least on recipient to the component:
+
+```rust
+pub fn add_recipient(&mut self, recipient: Address) {
+    self.recipients.push(recipient);
+}
+```
+
+When sending an airdrop, the component calculates the amount of tokens that every recipient should receive. Tokens are
+distributed evenly between all recipient. Note, however, that the last recipient is handled a bit differently as they
+are given the remaining tokens in the bucket after all other recipient have gotten their share. This is done so that no
+tokens remain in the input bucket due to rounding errors. If we were to implement this naively, the Scrypto Engine would
+stop us in certain scenarios.
+
+```rust
+pub fn perform_airdrop(&self, tokens: Bucket) {
+    let num_recipients = self.recipients.len();
+    assert!(num_recipients > 0, "You must register at least one recipient before performing an airdrop");
+
+    // Calculate the amount of tokens each recipient can receive
+    let amount_per_recipient = tokens.amount() / Decimal::from(num_recipients as i128);
+
+    // Send that amount to all but the last recipients
+    for i in 0..(num_recipients - 1) {
+        let address = self.recipients.get(i).unwrap();
+        Account::from(*address).deposit(tokens.take(amount_per_recipient));
+    }
+
+    // Send the remaining tokens to the last recipient.
+    // This should be almost exactly the calculated amount except for rounding errors. This way we can be sure
+    // not to loose any tokens.
+    let last_address = self.recipients.get(num_recipients - 1).unwrap();
+    Account::from(*last_address).deposit(tokens);
+}
+```

--- a/basic/airdrop/README.md
+++ b/basic/airdrop/README.md
@@ -3,25 +3,31 @@
 Example for an airdrop component that demonstrates how tokens can be sent to account addresses from within a component.
 Additional the code in `tests/libs.rs` shows how token balances can be retrieved in unit tests.
 
-The component is implemented in its simplest form to showcase the above two points. Authorization is not implemented.
+The component is implemented in its simplest form to showcase the above two points.
 
 # Implementation
 
-An airdrop component is instantiated without any arguments. It only holds one field, which is a vector that tracks the
-recipients of an airdrop:
+An airdrop component is instantiated without any arguments. It only holds two fields, which are a vector that tracks
+the recipients of an airdrop and an admin badge that is used for authorization:
 
 ```rust
-pub fn new() -> Component {
-    Self {
-        recipients: Vec::new(),
+pub fn new() -> (Component, Bucket) {
+    let admin_badge = ResourceBuilder::new().new_badge_fixed(1);
+
+    let component = Self {
+        admin_badge: admin_badge.resource_def(),
+        recipients: Vec::new()
     }
-        .instantiate()
+        .instantiate();
+
+    (component, admin_badge)
 }
 ```
 
 Before distributing an airdrop, one needs to first add at least on recipient to the component:
 
 ```rust
+#[auth(admin_badge)]
 pub fn add_recipient(&mut self, recipient: Address) {
     self.recipients.push(recipient);
 }
@@ -34,6 +40,7 @@ tokens remain in the input bucket due to rounding errors. If we were to implemen
 stop us in certain scenarios.
 
 ```rust
+#[auth(admin_badge)]
 pub fn perform_airdrop(&self, tokens: Bucket) {
     let num_recipients = self.recipients.len();
     assert!(num_recipients > 0, "You must register at least one recipient before performing an airdrop");
@@ -50,7 +57,7 @@ pub fn perform_airdrop(&self, tokens: Bucket) {
     // Send the remaining tokens to the last recipient.
     // This should be almost exactly the calculated amount except for rounding errors. This way we can be sure
     // not to loose any tokens.
-    let last_address = self.recipients.get(num_recipients - 1).unwrap();
+    let last_address = self.recipients.get(num_recipients-1).unwrap();
     Account::from(*last_address).deposit(tokens);
 }
 ```

--- a/basic/airdrop/src/lib.rs
+++ b/basic/airdrop/src/lib.rs
@@ -2,21 +2,29 @@ use scrypto::prelude::*;
 
 blueprint! {
     struct Airdrop {
+        admin_badge: ResourceDef,
         recipients: Vec<Address>,
     }
 
     impl Airdrop {
-        pub fn new() -> Component {
-            Self {
-                recipients: Vec::new(),
+        pub fn new() -> (Component, Bucket) {
+            let admin_badge = ResourceBuilder::new().new_badge_fixed(1);
+
+            let component = Self {
+                admin_badge: admin_badge.resource_def(),
+                recipients: Vec::new()
             }
-            .instantiate()
+            .instantiate();
+
+            (component, admin_badge)
         }
 
+        #[auth(admin_badge)]
         pub fn add_recipient(&mut self, recipient: Address) {
             self.recipients.push(recipient);    
         }
 
+        #[auth(admin_badge)]
         pub fn perform_airdrop(&self, tokens: Bucket) {
             let num_recipients = self.recipients.len();
             assert!(num_recipients > 0, "You must register at least one recipient before performing an airdrop");

--- a/basic/airdrop/src/lib.rs
+++ b/basic/airdrop/src/lib.rs
@@ -1,0 +1,40 @@
+use scrypto::prelude::*;
+
+blueprint! {
+    struct Airdrop {
+        recipients: Vec<Address>,
+    }
+
+    impl Airdrop {
+        pub fn new() -> Component {
+            Self {
+                recipients: Vec::new(),
+            }
+            .instantiate()
+        }
+
+        pub fn add_recipient(&mut self, recipient: Address) {
+            self.recipients.push(recipient);    
+        }
+
+        pub fn perform_airdrop(&self, tokens: Bucket) {
+            let num_recipients = self.recipients.len();
+            assert!(num_recipients > 0, "You must register at least one recipient before performing an airdrop");
+
+            // Calculate the amount of tokens each recipient can receive
+            let amount_per_recipient = tokens.amount() / Decimal::from(num_recipients as i128);
+
+            // Send that amount to all but the last recipients
+            for i in 0..(num_recipients - 1) {
+                let address = self.recipients.get(i).unwrap();
+                Account::from(*address).deposit(tokens.take(amount_per_recipient));
+            }
+
+            // Send the remaining tokens to the last recipient.
+            // This should be almost exactly the calculated amount except for rounding errors. This way we can be sure
+            // not to loose any tokens.
+            let last_address = self.recipients.get(num_recipients-1).unwrap();
+            Account::from(*last_address).deposit(tokens);
+        }
+    }
+}

--- a/basic/airdrop/tests/lib.rs
+++ b/basic/airdrop/tests/lib.rs
@@ -1,0 +1,165 @@
+use radix_engine::ledger::*;
+use radix_engine::transaction::*;
+use scrypto::prelude::*;
+
+#[test]
+fn test_airdrop_0_users() {
+    let mut ledger = InMemoryLedger::with_bootstrap();
+
+    // Set up environment.
+    let mut test_env = TestEnv::new(&mut ledger);
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+
+    let receipt = test_env.perform_airdrop(1000, RADIX_TOKEN);
+    assert!(!receipt.success);
+    let log_message = &receipt.logs.get(0).unwrap().1;
+    assert!(log_message.starts_with("Panicked at 'You must register at least one recipient before performing an airdrop'"));
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+}
+
+#[test]
+fn test_airdrop_1_user() {
+    let mut ledger = InMemoryLedger::with_bootstrap();
+
+    // Set up environment.
+    let mut test_env = TestEnv::new(&mut ledger);
+    let (_, user1_account) = test_env.new_account();
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+    assert_eq!(test_env.get_balance(user1_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+
+    test_env.add_recipient(user1_account);
+
+    let receipt = test_env.perform_airdrop(1000, RADIX_TOKEN);
+    println!("{:?}", receipt);
+    assert!(receipt.success);
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("999000").unwrap());
+    assert_eq!(test_env.get_balance(user1_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1001000").unwrap());
+}
+
+#[test]
+fn test_airdrop_3_users() {
+    let mut ledger = InMemoryLedger::with_bootstrap();
+
+    // Set up environment.
+    let mut test_env = TestEnv::new(&mut ledger);
+    let (_, user1_account) = test_env.new_account();
+    let (_, user2_account) = test_env.new_account();
+    let (_, user3_account) = test_env.new_account();
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+    assert_eq!(test_env.get_balance(user1_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+    assert_eq!(test_env.get_balance(user2_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+    assert_eq!(test_env.get_balance(user3_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000000").unwrap());
+
+    test_env.add_recipient(user1_account);
+    test_env.add_recipient(user2_account);
+    test_env.add_recipient(user3_account);
+
+    let receipt = test_env.perform_airdrop(1000, RADIX_TOKEN);
+    assert!(receipt.success);
+
+    assert_eq!(test_env.get_balance(test_env.admin_account, RADIX_TOKEN).unwrap(), Decimal::from_str("999000").unwrap());
+    assert_eq!(test_env.get_balance(user1_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000333.333333333333333333").unwrap());
+    assert_eq!(test_env.get_balance(user2_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000333.333333333333333333").unwrap());
+    assert_eq!(test_env.get_balance(user3_account, RADIX_TOKEN).unwrap(), Decimal::from_str("1000333.333333333333333334").unwrap());
+}
+
+struct TestEnv<'a> {
+    executor: TransactionExecutor<'a, InMemoryLedger>,
+    admin_key: Address,
+    admin_account: Address,
+    component: Address,
+}
+
+impl<'a> TestEnv<'a> {
+    pub fn new(ledger: &'a mut InMemoryLedger) -> Self {
+        let mut executor = TransactionExecutor::new(ledger, 0, 0);
+
+        let package = executor.publish_package(include_code!());
+        let admin_key = executor.new_public_key();
+        let admin_account = executor.new_account(admin_key);
+
+        let tx = TransactionBuilder::new(&executor)
+            .call_function(package, "Airdrop", "new", vec![], None)
+            .build(vec![admin_key])
+            .unwrap();
+        let receipt = executor.run(tx, false).unwrap();
+        println!("{:?}\n", receipt);
+        assert!(receipt.success);
+
+        Self {
+            executor,
+            admin_key,
+            admin_account,
+            component: receipt.component(0).unwrap(),
+        }
+    }
+
+    pub fn new_account(&mut self) -> (Address, Address) {
+        let key = self.executor.new_public_key();
+        (key, self.executor.new_account(key))
+    }
+
+    pub fn add_recipient(&mut self, recipient: Address) {
+        let tx = TransactionBuilder::new(&self.executor)
+            .call_method(
+                self.component,
+                "add_recipient",
+                vec![format!("{}", recipient)],
+                None,
+            )
+            .build(vec![self.admin_key])
+            .unwrap();
+        let receipt = self.executor.run(tx, false).unwrap();
+        println!("{:?}\n", receipt);
+        assert!(receipt.success);
+    }
+
+    fn perform_airdrop(&mut self, amount: i32, token: Address) -> Receipt {
+        let tx = TransactionBuilder::new(&self.executor)
+            .call_method(
+                self.component,
+                "perform_airdrop",
+                vec![format!("{},{}", amount, token)],
+                Some(self.admin_account),
+            )
+            .build(vec![self.admin_key])
+            .unwrap();
+        let receipt = self.executor.run(tx, false).unwrap();
+        println!("{:?}\n", receipt);
+        receipt
+    }
+
+    fn get_balance(&self, account: Address, token: Address) -> Result<Decimal, String> {
+        let ledger = self.executor.ledger();
+        let account_component = ledger.get_component(account).unwrap();
+        let mut vaults = vec![];
+        let _res = radix_engine::utils::format_data_with_ledger(
+            account_component
+                .state(radix_engine::model::Auth::NoAuth)
+                .unwrap(),
+            ledger,
+            &mut vaults,
+        ).unwrap();
+
+        for vid in vaults {
+            let vault = self.executor.ledger().get_vault(vid).unwrap();
+            let amount = vault.amount(radix_engine::model::Auth::NoAuth).unwrap();
+            let resource_def_address = vault
+                .resource_def(radix_engine::model::Auth::NoAuth)
+                .unwrap();
+            if token == resource_def_address {
+                return Ok(amount);
+            }
+        }
+
+        return Err(format!(
+            "No vault found for token {} in account {}",
+            token, account
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds an example for an airdrop component that may be used to distribute tokens to users.