### PR TITLE
Adds a TokenBurn component

### DIFF
--- a/basic/token-burn/Cargo.toml
+++ b/basic/token-burn/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "token-burn"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sbor = { path = "../../sbor" }
+scrypto = { path = "../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../radix-engine" }
+
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "out"

--- a/basic/token-burn/README.md
+++ b/basic/token-burn/README.md
@@ -1,0 +1,12 @@
+# TokenBurn
+Implementation of a component that "burns" all tokens that are sent to it.
+
+The component burns tokens by putting them into a vault to which no one holds a reference - not even the component itself.
+The tokens still exist on the ledger but are not accessible. Thus, they are effectively removed from circulation.
+
+```rust
+pub fn burn_tokens(&mut self, tokens_to_burn: Bucket) {
+    self.burnt_amount += tokens_to_burn.amount();
+    Vault::new(ResourceDef::from(self.token_address)).put(tokens_to_burn);
+}
+```

--- a/basic/token-burn/src/lib.rs
+++ b/basic/token-burn/src/lib.rs
@@ -1,0 +1,28 @@
+use scrypto::prelude::*;
+
+blueprint! {
+
+    struct TokenBurn {
+        token_address: Address,
+        burnt_amount: Decimal,
+    }
+
+    impl TokenBurn {
+        pub fn new(token_address: Address) -> Component {
+            Self {
+                token_address: token_address,
+                burnt_amount: Decimal::zero(),
+            }
+            .instantiate()
+        }
+
+        pub fn burn_tokens(&mut self, tokens_to_burn: Bucket) {
+            self.burnt_amount += tokens_to_burn.amount();
+            Vault::new(ResourceDef::from(self.token_address)).put(tokens_to_burn);
+        }
+
+        pub fn get_burnt_amount(&self) -> (Address, Decimal) {
+            (self.token_address, self.burnt_amount)
+        }
+    }
+}


### PR DESCRIPTION
This example illustrates how a component may be used to effectively burn tokens. This works as the Scrypto implementation currently allows dangling vaults, to which no entity holds a reference. See https://github.com/radixdlt/radixdlt-scrypto/issues/87