### PR TITLE
Alexandria (v0.2.0) compatibilitiy updates for defi/amms/bonding

### DIFF
--- a/defi/amms/bonding/Cargo.toml
+++ b/defi/amms/bonding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-bonding"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["devmannic <82296715+devmannic@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ A Scrypto package for creating and using bonding curves as an automated market m
 num-bigint = { version = "0.4.3", default-features = false, features = [] }
 num-rational = { version ="0.4.0", optional = true, default-features = false, features = ["num-bigint"] }
 num-traits = "0.2.14"
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
-scrypto_statictypes = { git = "https://github.com/devmannic/scrypto_statictypes", rev = "f9ce357" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
+scrypto_statictypes = { git = "https://github.com/devmannic/scrypto_statictypes", tag = "v0.2.0" }
 bonding_macros = { path = "bonding_macros" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
-scrypto-unit = { git = "https://github.com/plymth/scrypto-unit", rev = "4c179d1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
+scrypto-unit = { git = "https://github.com/plymth/scrypto-unit", rev = "9237a5d" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/defi/amms/bonding/Cargo.toml
+++ b/defi/amms/bonding/Cargo.toml
@@ -30,7 +30,6 @@ panic = 'abort'     # Abort on panic.
 
 [lib]
 crate-type = ["cdylib", "lib"]
-name = "out"
 path = "src/lib.rs"
 
 [features]

--- a/defi/amms/bonding/README.md
+++ b/defi/amms/bonding/README.md
@@ -42,9 +42,5 @@ Code
 * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7b7ff729b82ea73ea168e495d9c94cb901ae95ce/contracts/math/Power.sol
 * https://github.com/bancorprotocol/contracts-solidity/blob/c9adc95e82fdfb3a0ada102514beb8ae00147f5d/solidity/contracts/converter/BancorFormula.sol
 
-## Notes:
-
-The initial release is pre-Alexandria with expected (minimal) API incompatabilities
-
 
 License: MIT OR Apache-2.0

--- a/defi/amms/bonding/tests/lib.rs
+++ b/defi/amms/bonding/tests/lib.rs
@@ -27,7 +27,7 @@ fn setup_fixture<'a, L: Ledger>(env: &mut TestEnv<'a, L>) -> (User, User, Resour
 
     const PACKAGE: &str = "bonding";
 
-    env.publish_package(PACKAGE, include_code!("out"));
+    env.publish_package(PACKAGE, include_code!("scrypto_bonding"));
     env.using_package(PACKAGE);
 
     (owner, investor, reserve_def)

--- a/defi/amms/bonding/tests/lib.rs
+++ b/defi/amms/bonding/tests/lib.rs
@@ -27,7 +27,7 @@ fn setup_fixture<'a, L: Ledger>(env: &mut TestEnv<'a, L>) -> (User, User, Resour
 
     const PACKAGE: &str = "bonding";
 
-    env.publish_package(PACKAGE, include_code!());
+    env.publish_package(PACKAGE, include_code!("out"));
     env.using_package(PACKAGE);
 
     (owner, investor, reserve_def)
@@ -271,7 +271,7 @@ fn test_3_quotes() {
     ]);
     println!("buy_quote: receipt: {:?}", receipt);
     assert!(receipt.success);
-    let quote: Decimal = utils::return_of_call_method(&mut receipt, "get_buy_quote_amount");
+    let quote: Decimal = return_of_call_method(&mut receipt, "get_buy_quote_amount");
     assert_eq!(quote, 300.into());
 
     // now try to get a sell quote amount and see if it's right
@@ -280,7 +280,7 @@ fn test_3_quotes() {
     ]);
     println!("sell_quote_amount: receipt: {:?}", receipt);
     assert!(receipt.success);
-    let quote: Decimal = utils::return_of_call_method(&mut receipt, "get_sell_quote_amount");
+    let quote: Decimal = return_of_call_method(&mut receipt, "get_sell_quote_amount");
     assert_eq!(quote, 300.into());
 
     // now try to get a seel quote (BucketRef) ...but can't check it easily outside of wasm
@@ -296,16 +296,4 @@ fn test_3_quotes() {
     let expected_reserve_in_account: Decimal = 1_000_000.into();
     let reserve_in_account = env.get_amount_for_rd(user.account, reserve_def.address());  
     assert_eq!(reserve_in_account, expected_reserve_in_account);
-}
-
-mod utils {
-    // TODO remove after upstreamed into scrypto-unit
-    use scrypto::prelude::*;
-    use sbor::Decode;
-    use radix_engine::transaction::*;
-    pub fn return_of_call_method<T: Decode>(receipt: &mut Receipt, method_name: &str) -> T {
-        let instruction_index = receipt.transaction.instructions.iter().position(|i| match i { Instruction::CallMethod { ref method, .. } if method == method_name => true, _ => false }).unwrap();
-        let encoded = receipt.results.swap_remove(instruction_index).unwrap().unwrap().encoded;
-        scrypto_decode(&encoded).unwrap()
-    }
 }


### PR DESCRIPTION
* pin to v0.2.0 for `scrypto_statictypes` and updated rev for scrypto-unit.
* API updates to use new ResourceBuilder etc.
* bump package version
* remove "pre-Alexandria" note from the README